### PR TITLE
Fixing a fatal error + minor copy-paste issue in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ if(esp8266_at_ver != None):
 '''
 set the current WiFi in SoftAP+STA
 '''
-print("WiFi Current Mode:",esp01.setCurrentWiFiMode()
+print("WiFi Current Mode:",esp01.setCurrentWiFiMode())
   
 print("\r\n\r\n")
 

--- a/esp8266.py
+++ b/esp8266.py
@@ -459,7 +459,7 @@ class ESP8266:
             return 0, None
             
         
-    def doHttpPost(self,host,path,user_agent="RPi-Pico",content_type,content,port=80):
+    def doHttpPost(self,host,path,content_type,content,user_agent="RPi-Pico",port=80):
         """
         This fucntion use to complete a HTTP Post operation
         


### PR DESCRIPTION
Hello, 

A minor error in the Readme which I found during copy-paste. 

And a Major Fatal error on line 462 was found during execution: 

`>>> %Run -c $EDITOR_CONTENT
Traceback (most recent call last):
  File "<stdin>", line 462, in ESP8266
SyntaxError: non-default argument follows default argument`

Leaving the default arguments at the end fixes it. 

:)